### PR TITLE
Fix login issue caused by Kodi PR 12125

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
   <category label="Login">
+      <setting id="email" type="text" visible="false" label="E-Mail" default="" />
+      <setting id="password" type="text" visible="false" label="Passwort" default="" />
       <setting id="set_login" type="action" label="Anmelden..." action="RunPlugin(plugin://plugin.video.skygo.de/?action=login)" option="close"/>
       <setting id="login_acc" type="text" label="Angemeldet als" enable="eq(-100,true)" default="" subsetting="true"/>
       <setting id="autoKillSession" type="bool" default="false" label="Andere Sessions automatisch beenden"></setting>


### PR DESCRIPTION
As discussed, due to the changes, probably caused by Kodi [PR 12125](https://github.com/xbmc/xbmc/pull/12125), setting IDs set directly by the python addon are not passed to the addon.foo.bar/settings.xml file, like it was before. This PR is more a hack then a real solution, the PR just adds the non passed setting IDs to the addon.foo.bar/resources/settings.xml file and will restore the possibility to write all setting IDs to the addon.foo.bar/settings.xml file and assures a save login. 
There is the possibility that this PR could be removed in the near future.
