### PR TITLE
Single skygo instance

### DIFF
--- a/default.py
+++ b/default.py
@@ -11,10 +11,18 @@ from skygo import SkyGo
 import navigation as nav
 import watchlist
 
-skygo = SkyGo()
-addon_handle = int(sys.argv[1])
 plugin_base_url = sys.argv[0]
 params = dict(urlparse.parse_qsl(sys.argv[2][1:]))
+
+addon_handle = int(sys.argv[1])
+skygo = SkyGo(addon_handle)
+
+vod.skygo = skygo
+nav.skygo = skygo
+clips.skygo = skygo
+liveTv.skygo = skygo
+watchlist.skygo = skygo
+
 
 # Router for all plugin actions
 if 'action' in params:

--- a/resources/lib/clips.py
+++ b/resources/lib/clips.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
 import json
 import time
 import base64
@@ -10,8 +9,8 @@ import urllib
 from crypto.cipher import aes_cbc
 #pycrypto
 #from Crypto.Cipher import AES
-from skygo import SkyGo
-skygo = SkyGo()
+
+skygo = None
 
 secret_key = 'XABD-FHIM-GDFZ-OBDA-URDG-TTRI'
 aes_key = ['826cf604accd0e9d61c4aa03b7d7c890', 'da1553b1515bd6f5f48e250a2074d30c']

--- a/resources/lib/liveTv.py
+++ b/resources/lib/liveTv.py
@@ -1,17 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
 import requests
 import xbmcaddon
 import xbmcgui
 import xbmcplugin
 import ast
-from skygo import SkyGo
 
-addon_handle = int(sys.argv[1])
 addon = xbmcaddon.Addon()
-skygo = SkyGo()
+skygo = None
 
 def playLiveTv(manifest_url, package_code, infolabels='', parental_rating=0):
     #hardcoded apixId for live content

--- a/resources/lib/vod.py
+++ b/resources/lib/vod.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
 import ast
-from skygo import SkyGo
 import navigation as nav
 
-skygo = SkyGo()
+skygo = None
 
 def playAsset(asset_id, infolabels='', parental_rating=0):
     #get asset details and build infotag from it

--- a/skygo.py
+++ b/skygo.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
 import base64
 import struct
 
@@ -28,7 +27,6 @@ LOGIN_STATUS = { 'SUCCESS': 'T_100',
                   'OTHER_SESSION':'T_206' }
 
 addon = xbmcaddon.Addon()
-addon_handle = int(sys.argv[1])
 autoKillSession = addon.getSetting('autoKillSession')
 username = addon.getSetting('email')
 password = addon.getSetting('password')
@@ -72,12 +70,13 @@ class SkyGo:
     entitlements = []
 
 
-    def __init__(self):
+    def __init__(self, addon_handle):
         self.sessionId = ''
         self.cookiePath = cookiePath
         self.license_url = license_url
         self.license_type = license_type
         self.android_deviceId = android_deviceid
+        self.addon_handle = addon_handle
 
         # Create session with old cookies
         self.session = requests.session()
@@ -336,7 +335,7 @@ class SkyGo:
                     li.setProperty('inputstream.adaptive.license_data', init_data)
                 li.setProperty('inputstreamaddon', 'inputstream.adaptive')
                 # Start Playing
-                xbmcplugin.setResolvedUrl(addon_handle, True, listitem=li)
+                xbmcplugin.setResolvedUrl(self.addon_handle, True, listitem=li)
             else:
                 xbmcgui.Dialog().notification('Sky Go Fehler', 'Keine Berechtigung zum Abspielen dieses Eintrags', xbmcgui.NOTIFICATION_ERROR, 2000, True)
         else:

--- a/watchlist.py
+++ b/watchlist.py
@@ -1,18 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
 import json
 import xbmc
 import xbmcaddon
 import xbmcgui
 import xbmcplugin
 import resources.lib.common as common
-from skygo import SkyGo
 import navigation as nav
-skygo = SkyGo()
+skygo = None
 
-addon_handle = int(sys.argv[1])
 base_url = 'https://www.skygo.sky.de/SILK/services/public/watchlist/'
 
 def rootDir():
@@ -25,7 +22,7 @@ def rootDir():
     url = common.build_url({'action': 'watchlist', 'list': 'Sport'})
     nav.addDir('Sport', url)
 
-    xbmcplugin.endOfDirectory(addon_handle, cacheToDisc=False)    
+    xbmcplugin.endOfDirectory(skygo.addon_handle, cacheToDisc=False)    
 
 def listWatchlist(asset_type, page=0):
     skygo.login()


### PR DESCRIPTION
In near future kodi will keep python sessions open during navigating in one addon.
At this time only default.py will be reloaded and all the other submodules remain in python cache.

Accessing command line arguments (sys.argv[#] will only work in default.py and has to be passed in any way to the submodules which require them (e.g. addon_handle)

Because I'm lazy I kept most of the code untouched and only (re)initialize the global skygo instance (which includes the addon_handle) from default.py. Other ways would be using classes or passing required argument values using function parameters.